### PR TITLE
Fieldset: Allow quering items with incomplete key paths

### DIFF
--- a/input/utils/fieldset.js
+++ b/input/utils/fieldset.js
@@ -1,8 +1,11 @@
 'use strict';
 
 var assign          = require('es5-ext/object/assign')
+  , ensureString    = require('es5-ext/object/validate-stringifiable-value')
   , forEach         = require('es5-ext/object/for-each')
+  , some            = require('es5-ext/object/some')
   , startsWith      = require('es5-ext/string/#/starts-with')
+  , endsWith        = require('es5-ext/string/#/ends-with')
   , toArray         = require('es5-ext/array/to-array')
   , d               = require('d')
   , autoBind        = require('d/auto-bind')
@@ -63,6 +66,18 @@ Object.defineProperties(Fieldset.prototype, assign({
 		li = this.document.createElement('li');
 		li.appendChild(dom);
 		return li;
+	}),
+	getItem: d(function (path) {
+		var result = null;
+		path = ensureString(path);
+		if (path[0] === '/') path = path.slice(1);
+		some(this.items, function (item, key) {
+			if ((key === path) || endsWith.call(key, '/' + path)) {
+				result = item;
+				return true;
+			}
+		});
+		return result;
 	}),
 	toDOM: d(function () { return this.dom; }),
 	getOptions: d(DOMComposite.prototype.getOptions)

--- a/input/utils/fieldset.js
+++ b/input/utils/fieldset.js
@@ -72,9 +72,10 @@ Object.defineProperties(Fieldset.prototype, assign({
 	getItem: d(function (path) {
 		var result = null;
 		path = ensureString(path);
-		if (path[0] === '/') path = path.slice(1);
+		if (this.items[path]) return this.items[path];
+		if (path[0] !== '/') path = '/' + path;
 		some(this.items, function (item, key) {
-			if ((key === path) || endsWith.call(key, '/' + path)) {
+			if (endsWith.call(key, path)) {
 				result = item;
 				return true;
 			}

--- a/input/utils/fieldset.js
+++ b/input/utils/fieldset.js
@@ -67,6 +67,8 @@ Object.defineProperties(Fieldset.prototype, assign({
 		li.appendChild(dom);
 		return li;
 	}),
+	// Allows to retrieve a generated item (field) by path string
+	// (property path must end with provided path string)
 	getItem: d(function (path) {
 		var result = null;
 		path = ensureString(path);


### PR DESCRIPTION
/cc @kamsi

Currently items can be get only vie full path, which is not very handy in many situations
