### PR TITLE
Allow for dynamic labels on observables.

### DIFF
--- a/input/observable.js
+++ b/input/observable.js
@@ -111,8 +111,13 @@ Object.defineProperties(PropObserv.prototype, {
 		}
 		input = this.toDOMInput(document, inputOptions);
 
-		if (options.label === false) options.label = null;
-		else if (options.label == null) options.label = desc.label;
+		if (options.label == null) {
+			options.label = desc.dynamicLabelKey ? desc.object.getObservable(desc.dynamicLabelKey)
+				: desc.label;
+		} else if (options.label === false) {
+			options.label = null;
+		}
+
 		if (options.hint == null) options.hint = desc.inputHint;
 		if (options.optionalInfo == null) options.optionalInfo = desc.inputOptionalInfo;
 


### PR DESCRIPTION
While it would be great to be able to define getters on descriptor, currently it's not doable. Instead, provide `dynamicLabelKey` descriptor property that would point to _label_ property on object.
